### PR TITLE
Feat : Intent 결과로 uri로 가져온 것을 filePath로 변환하는 함수 및 filePath를 Multipart로 변환, DTO를 requestBody로 변환하는 함수 구현

### DIFF
--- a/Lee/ImageIntentResult/IntentResultHandler.kt
+++ b/Lee/ImageIntentResult/IntentResultHandler.kt
@@ -1,0 +1,42 @@
+package com.gumibom.travelmaker.ui.common
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.fragment.app.FragmentActivity
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+import java.io.FileOutputStream
+
+
+/**
+ * 갤러리 또는 카메라 Intent로 결과를 가져왔을 때 처리를 담당하는 Class
+ */
+class IntentResultHandler {
+
+    /**
+     * Uri를 휴대폰 FilePath로 변환하는 함수
+     */
+    fun getFilePathUri(fragmentActivity: FragmentActivity, uri : Uri) : String {
+        val buildName = Build.MANUFACTURER
+
+        // 샤오미 폰은 바로 경로 반환 가능
+        if (buildName.equals("Xiaomi")) {
+            return uri.path.toString()
+        }
+
+        var columnIndex = 0
+        val proj = arrayOf(MediaStore.Images.Media.DATA)
+        var cursor = fragmentActivity.contentResolver.query(uri, proj, null, null, null)
+
+        if (cursor!!.moveToFirst()){
+            columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+        }
+
+        return cursor.getString(columnIndex)
+    }
+}

--- a/Lee/MultiPart/MultiPartHandler.kt
+++ b/Lee/MultiPart/MultiPartHandler.kt
@@ -1,0 +1,25 @@
+package com.gumibom.travelmaker.ui.common
+
+import com.google.gson.Gson
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
+
+class MultiPartHandler {
+
+    fun convertMultiPart(filePath : String, imageKey : String) : MultipartBody.Part {
+        val file = File(filePath)
+        val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
+
+        return MultipartBody.Part.createFormData(imageKey, file.name, requestFile)
+    }
+
+    fun <T> createRequestBody(requestDTO : T) : RequestBody {
+        val gson = Gson()
+        val productJson = gson.toJson(requestDTO)
+        return productJson.toRequestBody("application/json".toMediaTypeOrNull())
+    }
+}


### PR DESCRIPTION
IntentResultHandler 클래스의
getFilePathUri() 함수는 fragmentAcitivity를 인자로 받고 있으므로 Fragment에서만 사용이 가능합니다.

MultiPartHandler 클래스의 
convertMultiPart() 함수는 val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull()) 로 변환하므로 이미지만 변환이 가능합니다.